### PR TITLE
Adding CLOB handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,18 @@
 # maven output directory
 target/
 
+#Ignore everuthing in /.idea
+**/.idea
+
+
 # Eclipse files
 bin/
 .settings/
 .classpath
 .project
+
+#Ignore idea settings
+*.iml
 
 # Excel
 ~*

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.exigeninsurance.x4j.analytic</groupId>
-	<version>1.0.13</version>
+	<version>1.0.14</version>
 	<artifactId>x4j-analytic</artifactId>
 	<name>XLSX Transformations</name>	
     <description>
@@ -109,6 +109,13 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.oracle</groupId>
+			<artifactId>ojdbc14</artifactId>
+			<version>10.2.0.2.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,14 @@
     </license>
   </licenses>
 
+  <repositories>
+	<!-- Repository for ORACLE ojdbc6. -->
+	<repository>
+	    <id>codelds</id>
+	    <url>https://code.lds.org/nexus/content/groups/main-repo</url>
+	</repository>
+  </repositories>
+
   <scm>
     <url>https://github.com/jbaliuka/x4j-analytic.git</url>
      <connection>scm:git:https://github.com/jbaliuka/x4j-analytic.git</connection>
@@ -114,8 +122,8 @@
 
 		<dependency>
 			<groupId>com.oracle</groupId>
-			<artifactId>ojdbc14</artifactId>
-			<version>10.2.0.2.0</version>
+			<artifactId>ojdbc6</artifactId>
+			<version>11.2.0.3</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -4,7 +4,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.exigeninsurance.x4j.analytic</groupId>
-	<version>1.0.13</version>
+	<version>1.0.14</version>
 	<artifactId>x4j-analytic-samples</artifactId>
 	<name>XLSX Transformations</name>
 

--- a/src/main/java/com/exigeninsurance/x4j/analytic/api/CursorMetadataFabric.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/api/CursorMetadataFabric.java
@@ -1,0 +1,14 @@
+package com.exigeninsurance.x4j.analytic.api;
+
+import com.exigeninsurance.x4j.analytic.util.CursorMetadata;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Created by kkolesnichenko on 5/24/2016.
+ */
+public interface CursorMetadataFabric{
+
+    CursorMetadata createFromResultSet(ResultSet rs) throws SQLException;
+}

--- a/src/main/java/com/exigeninsurance/x4j/analytic/util/CursorMetadata.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/util/CursorMetadata.java
@@ -116,13 +116,13 @@ public class CursorMetadata implements Serializable {
 				}
 
 				oout.flush();
-				byte[] bytes  = out.toByteArray();
-				objectOut.writeInt(bytes .length);
-				objectOut.write(bytes );
+				byte[] bytes = out.toByteArray();
+				objectOut.writeInt(bytes.length);
+				objectOut.write(bytes);
 			} finally {
 				oout.close();
 			}
-		} finally {
+		}finally{
 			out.close();
 		}
 	}

--- a/src/main/java/com/exigeninsurance/x4j/analytic/util/CursorMetadata.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/util/CursorMetadata.java
@@ -116,9 +116,9 @@ public class CursorMetadata implements Serializable {
 				}
 
 				oout.flush();
-				byte[] var14 = out.toByteArray();
-				objectOut.writeInt(var14.length);
-				objectOut.write(var14);
+				byte[] bytes  = out.toByteArray();
+				objectOut.writeInt(bytes .length);
+				objectOut.write(bytes );
 			} finally {
 				oout.close();
 			}

--- a/src/main/java/com/exigeninsurance/x4j/analytic/util/CursorMetadata.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/util/CursorMetadata.java
@@ -5,20 +5,14 @@
 
 package com.exigeninsurance.x4j.analytic.util;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
+import java.io.*;
+import java.sql.Clob;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
 import com.exigeninsurance.x4j.analytic.api.Cursor;
-
+import com.exigeninsurance.x4j.analytic.api.CursorMetadataFabric;
 
 
 public class CursorMetadata implements Serializable {
@@ -51,9 +45,39 @@ public class CursorMetadata implements Serializable {
 		String[] columns = new  String[metaData.getColumnCount()];
 		int count =  metaData.getColumnCount();
 		for (int i = 0; i < count; i++) {
-			columns[i] = metaData.getColumnName(i + 1);            
+			columns[i] = metaData.getColumnName(i + 1);
 		}
 		return new CursorMetadata(columns);
+	}
+
+	/*
+	 //Alternative implementation
+	 public static CursorMetadata createFromResultSet(final ResultSet rs) throws SQLException {
+	 	return createFromResultSet(rs, new CursorMetadataFabric(){
+
+			@Override
+			public CursorMetadata createFromResultSet(ResultSet rs) throws SQLException {
+				ResultSetMetaData metaData = rs.getMetaData();
+				String[] columns = new  String[metaData.getColumnCount()];
+				int count =  metaData.getColumnCount();
+				for (int i = 0; i < count; i++) {
+					columns[i] = metaData.getColumnName(i + 1);
+				}
+				return new CursorMetadata(columns);
+			}
+		});
+	 }
+	*/
+
+	/**
+	 * Provide ability for custom fabric and extension of CursorMetadata
+	 * @param rs
+	 * @param cursorMetadataFabric
+	 * @return
+	 * @throws SQLException
+	 */
+	public static CursorMetadata createFromResultSet(ResultSet rs, CursorMetadataFabric cursorMetadataFabric) throws SQLException {
+		return cursorMetadataFabric.createFromResultSet(rs);
 	}
 
 	public Object[] readRow(DataInput data) throws IOException, ClassNotFoundException {
@@ -75,27 +99,46 @@ public class CursorMetadata implements Serializable {
 	}
 
 	public void writeRow(DataOutput objectOut, Cursor rs) throws IOException, SQLException {
-
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		try{
-			ObjectOutputStream oout = new ObjectOutputStream(out);	
-			try{
-				
-				for(int i = 0 ; i < columns.length; i++ ){					
-					oout.writeObject( rs.getObject(i + 1));
+
+		try {
+			ObjectOutputStream oout = new ObjectOutputStream(out);
+
+			try {
+				for(int bytes = 0; bytes < this.columns.length; ++bytes) {
+					Object obj=rs.getObject(bytes + 1);
+					if(obj instanceof Clob){
+						oout.writeObject(clobToString((Clob)obj));
+					}
+					else{
+						oout.writeObject(obj);
+					}
 				}
-				
+
 				oout.flush();
-				byte[] bytes = out.toByteArray();
-				objectOut.writeInt(bytes.length);
-				objectOut.write(bytes);
-			}finally{
+				byte[] var14 = out.toByteArray();
+				objectOut.writeInt(var14.length);
+				objectOut.write(var14);
+			} finally {
 				oout.close();
 			}
-		}finally{
+		} finally {
 			out.close();
 		}
-
 	}
-	
+
+	private Serializable clobToString(Clob data) throws SQLException, IOException {
+		StringBuilder sb = new StringBuilder();
+		BufferedReader br = new BufferedReader( data.getCharacterStream());
+		try {
+			String line;
+			while(null != (line = br.readLine())) {
+				sb.append(line);
+			}
+		} finally {
+			br.close();
+		}
+		return sb;
+	}
+
 }


### PR DESCRIPTION
Was observed that CursorMetadata#writeRow fails on working with oracle CLOB datatype since it contains not serializable fields like connection. And maybe we don't need for such cases to store all this info. We forced this limitation when we tried to serialaze string field from database longer than 4000 bytes.
Here is proposal to fix it and provide posibility to extend CursorMetadata and instantiate it using custom CursorMetadataFabric.