### PR TITLE
Fixing squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/exigeninsurance/x4j/analytic/util/IOUtils.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/util/IOUtils.java
@@ -25,6 +25,10 @@ public class IOUtils {
 	private static final int BUFFER_SIZE = 1024*80;
 	private static final Logger log = LoggerFactory.getLogger(IOUtils.class);
 
+    private IOUtils() {
+
+    }
+
 	public static void delete(File temtFile) {
 		if(!temtFile.delete()){
 			log.warn("unable to delete " + temtFile);

--- a/src/main/java/com/exigeninsurance/x4j/analytic/util/MockResultSet.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/util/MockResultSet.java
@@ -25,6 +25,11 @@ abstract public class MockResultSet implements ResultSet {
 		return create(columns,rows,0);
 
 	}
+
+    private MockResultSet() {
+
+    }
+
 	public static ResultSet create(final String[] columns,final Object[][] rows, final int generate){
         return (ResultSet) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class[]{ResultSet.class}, new InvocationHandler() {
 

--- a/src/main/java/com/exigeninsurance/x4j/analytic/util/ReportUtil.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/util/ReportUtil.java
@@ -36,6 +36,10 @@ public class ReportUtil {
 	private static final String MODEL_PACKAGE = "com.exigeninsurance.x4j.analytic.model";
 	public static final JexlEngine ENGINE = new JexlEngine();
 
+    private ReportUtil() {
+
+    }
+
 	public static void validate(InputStream is,final List<String> messages){
 		try {
 			JAXBContext	jc = JAXBContext.newInstance( MODEL_PACKAGE );

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/PDFHelper.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/PDFHelper.java
@@ -40,6 +40,10 @@ public class PDFHelper {
     public static final int EMU_PER_POINT = 12700;
     public static final int EMU_PER_CM = 360000;
 
+    private PDFHelper() {
+
+    }
+
     private static final float CHARACTER_WIDTH;
 
     static {

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/CellWidthEstimator.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/CellWidthEstimator.java
@@ -10,6 +10,11 @@ import org.apache.poi.xssf.usermodel.XSSFCell;
 
 
 public class CellWidthEstimator {
+
+    private CellWidthEstimator() {
+        
+    }
+
 	public static double getCellWidth(XSSFCell cell, String value) {
 		return cell.getCellStyle().getWrapText() ? 2 : value.length() + 2;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - "Utility classes should not have public constructors".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S1118
Please let me know if you have any questions.
Artyom Melnikov