### PR TITLE
Fixing squid:S2111 and squid:S2974

### DIFF
--- a/src/main/java/com/exigeninsurance/x4j/analytic/util/StringUtils.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/util/StringUtils.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import java.util.Iterator;
 
 
-public class StringUtils {
+public final class StringUtils {
 	private StringUtils() {}
 	
 	public static String join(Object[] arr, String separator) {

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/html/HTMLCellNode.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/html/HTMLCellNode.java
@@ -64,7 +64,7 @@ class HTMLCellNode extends CellNode {
                 context.write(context.formatMoney((Money) value));
             }
             else if (value instanceof Number){
-                Money money = new Money(null, new BigDecimal(((Number) value).doubleValue()));
+                Money money = new Money(null, BigDecimal.valueOf(((Number) value).doubleValue()));
                 context.write(context.formatMoney(money));
             }
             else if (value instanceof Date) {

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/PdfCellNode.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/PdfCellNode.java
@@ -117,7 +117,7 @@ public class PdfCellNode extends CellNode implements DrawablePdfElement, PdfGrid
 		if (value instanceof Money) {
 			return context.formatMoney((Money) value).replaceAll(NON_BREAKING_SPACE, " ");
 		} else if (value instanceof Number) {
-			Money money = new Money(null, new BigDecimal(((Number) value).doubleValue()));
+			Money money = new Money(null, BigDecimal.valueOf(((Number) value).doubleValue()));
 			return context.formatMoney(money).replaceAll(NON_BREAKING_SPACE," ");
 		} else if (value instanceof Date) {
 			if (value instanceof Timestamp) {

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/StyleCache.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/StyleCache.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import com.exigeninsurance.x4j.analytic.model.Money;
 
 
-public class StyleCache {
+public final class StyleCache {
 
 	private final Map<XLSXCellNode, Long> styles = new HashMap<XLSXCellNode, Long>();
 	private final CurrencyStyleCache currencyStyles = new CurrencyStyleCache();

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXCellNode.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXCellNode.java
@@ -136,7 +136,7 @@ public final class XLSXCellNode extends CellNode {
 		if (value instanceof Money) {
 			return context.formatMoney((Money) value);
 		} else if (value instanceof Number) {
-			Money money = new Money(null, new BigDecimal(((Number) value).doubleValue()));
+			Money money = new Money(null, BigDecimal.valueOf(((Number) value).doubleValue()));
 			return context.formatMoney(money);
 		} else if (value instanceof Date) {
 			if (value instanceof Timestamp) {

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXStyleUtil.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXStyleUtil.java
@@ -20,7 +20,7 @@ import com.exigeninsurance.x4j.analytic.xlsx.core.localization.FormatProvider;
 import com.exigeninsurance.x4j.analytic.xlsx.transform.AlignmentFinder;
 
 
-public class XLSXStyleUtil {
+public final class XLSXStyleUtil {
 
 	private final StyleCache styleCache = new StyleCache();
 	private final XSSFSheet sheet;

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/utils/WrappingUtil.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/utils/WrappingUtil.java
@@ -16,7 +16,7 @@ import com.exigeninsurance.x4j.analytic.xlsx.transform.pdf.PdfCellNode;
 import com.exigeninsurance.x4j.analytic.xlsx.transform.xlsx.XLXContext;
 
 @Internal
-public class WrappingUtil {
+public final class WrappingUtil {
 
 	public static final String EXCEL_BREAK = " \r\n";
 	private static final char WRAPPING_BREAK = '\n';

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/utils/XSSFSheetHelper.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/utils/XSSFSheetHelper.java
@@ -19,7 +19,7 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTDefinedName;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTDefinedNames;
 
 @Internal
-public class XSSFSheetHelper {
+public final class XSSFSheetHelper {
 
     private static final Pattern ROWS_RANGE = Pattern.compile("\\$\\d*:\\$\\d*");
 	private static final Pattern COLUMN_RANGE = Pattern.compile("\\$[a-zA-Z]*:\\$[a-zA-Z]*");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules:
squid:S2111 - ""BigDecimal(double)" should not be used".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S2111
squid:S2974 - "Classes without "public" constructors should be "final"".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S2974
Please let me know if you have any questions.
Artyom Melnikov