### PR TITLE
Fixing squid:S1943 - Classes and methods that rely on the default system encoding should not be used

### DIFF
--- a/src/main/java/com/exigeninsurance/x4j/analytic/api/Cursor.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/api/Cursor.java
@@ -17,15 +17,15 @@ import com.exigeninsurance.x4j.analytic.util.CursorMetadata;
 
 public interface Cursor {
 
-    public void close();
+    void close();
     
-    public boolean isClosed();
+    boolean isClosed();
 
-    public boolean next();
+    boolean next();
 
-    public CursorMetadata getMetadata();
+    CursorMetadata getMetadata();
 
-    public Object getObject(int i);
+    Object getObject(int i);
 
-    public void reset();
+    void reset();
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/api/DefaultReportDataProvider.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/api/DefaultReportDataProvider.java
@@ -70,7 +70,7 @@ public class DefaultReportDataProvider implements ReportDataProvider {
 
 	private void execute(Query query, ReportContext context,
 			ReportDataCallback callback, Connection conn)
-					throws SQLException, Exception {
+					throws Exception {
 
 		String jdbcSql = paramPattern.matcher(query.getSql()).replaceAll("?");
 		PreparedStatement statement = conn.prepareStatement( jdbcSql );

--- a/src/main/java/com/exigeninsurance/x4j/analytic/api/Transform.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/api/Transform.java
@@ -26,10 +26,10 @@ public interface Transform {
 	 * @param saveTo output
 	 * @throws Exception
 	 */
-	public void process(ReportContext reportContext, InputStream template, File saveTo) throws Exception;
+    void process(ReportContext reportContext, InputStream template, File saveTo) throws Exception;
 	
-	public void setDataProvider(ReportDataProvider dataProvider);
+	void setDataProvider(ReportDataProvider dataProvider);
 	
-	public void setTemplateProvider(TemplateResolver resolver);
+	void setTemplateProvider(TemplateResolver resolver);
 
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/core/expression/XLSXExpression.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/core/expression/XLSXExpression.java
@@ -12,7 +12,7 @@ import com.exigeninsurance.x4j.analytic.xlsx.transform.xlsx.XLXContext;
 public interface XLSXExpression {
 
 	
-	public abstract Object evaluate(XLXContext context) throws Exception;
+	Object evaluate(XLXContext context) throws Exception;
 
 	
 

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/core/node/ResultSetAdapter.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/core/node/ResultSetAdapter.java
@@ -13,19 +13,19 @@ import com.exigeninsurance.x4j.analytic.xlsx.core.groups.GroupState;
 
 public interface ResultSetAdapter {
 	
-	public boolean next(String group);
+	boolean next(String group);
 	
-	public void getRow(Map<String, Object> destination);
+	void getRow(Map<String, Object> destination);
 	
-	public void close(String column);
+	void close(String column);
 	
-	public void addGroup(String group, GroupState initialState);
+	void addGroup(String group, GroupState initialState);
 	
-	public boolean last();
+	boolean last();
 	
-	public boolean first();
+	boolean first();
 	
-	public void push(String group);
+	void push(String group);
 	
-	public void pop();
+	void pop();
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/SST.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/SST.java
@@ -7,6 +7,7 @@
 package com.exigeninsurance.x4j.analytic.xlsx.transform;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.HashMap;
@@ -17,10 +18,10 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTRst;
 
 
 final public class SST{
-	private static final byte[] XML_SPACE_PRESERVE = " xml:space=\"preserve\"".getBytes();
-	private static final byte[] E = ">".getBytes();
-	private static final byte[] SI_T = "<si><t".getBytes();
-	private static final byte[] T_SI = "</t></si>\n".getBytes();
+	private static final byte[] XML_SPACE_PRESERVE = " xml:space=\"preserve\"".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] E = ">".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] SI_T = "<si><t".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] T_SI = "</t></si>\n".getBytes(StandardCharsets.UTF_8);
 
 	private final UTF8OutputStream out;
 	private final Map<String,Long> cache = new HashMap< String, Long>();

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/html/HTMLProcessor.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/html/HTMLProcessor.java
@@ -8,6 +8,7 @@ package com.exigeninsurance.x4j.analytic.xlsx.transform.html;
 
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -60,12 +61,12 @@ public class HTMLProcessor extends WorkbookProcessor {
 
 		buffer.append("</style>");
 
-		out.write( "<html>\n<head>\n".getBytes() );
-		out.write( buffer.toString().getBytes() );
+		out.write( "<html>\n<head>\n".getBytes(StandardCharsets.UTF_8) );
+		out.write( buffer.toString().getBytes(StandardCharsets.UTF_8) );
 
-		out.write("\n</head>\n<body>\n<table id=\"".getBytes());
-		out.write( "workbook".getBytes() );
-		out.write("\"><tr><td>\n".getBytes());
+		out.write("\n</head>\n<body>\n<table id=\"".getBytes(StandardCharsets.UTF_8));
+		out.write( "workbook".getBytes(StandardCharsets.UTF_8) );
+		out.write("\"><tr><td>\n".getBytes(StandardCharsets.UTF_8));
 
 		for(int i = 0; i < workBook.getNumberOfSheets(); i++){
 			nextSheet(reportContext, i);

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/ComponentFactory.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/ComponentFactory.java
@@ -15,25 +15,25 @@ import com.exigeninsurance.x4j.analytic.xlsx.transform.pdf.geometry.Range;
 
 
 public interface ComponentFactory {
-    public PdfCellNode createHeaderCell(XSSFSheet xssfSheet, XSSFCell cell, XLSXExpression expr);
+    PdfCellNode createHeaderCell(XSSFSheet xssfSheet, XSSFCell cell, XLSXExpression expr);
 
-    public PdfCellNode createTableCell(XSSFSheet xssfSheet, XSSFCell cell, XLSXExpression expr);
+    PdfCellNode createTableCell(XSSFSheet xssfSheet, XSSFCell cell, XLSXExpression expr);
 
-    public PdfCellNode createCell(XSSFSheet xssfSheet, XSSFCell cell, XLSXExpression expr);
+    PdfCellNode createCell(XSSFSheet xssfSheet, XSSFCell cell, XLSXExpression expr);
 
-    public PdfCellNode createEmptyCell(XSSFSheet xssfSheet, XSSFCell cell);
+    PdfCellNode createEmptyCell(XSSFSheet xssfSheet, XSSFCell cell);
 
-    public PdfContainer createTableRow(XSSFSheet sheet, Range verticalRange);
+    PdfContainer createTableRow(XSSFSheet sheet, Range verticalRange);
 
-    public PdfContainer createTableHeaderRow(XSSFSheet sheet, Range verticalRange);
+    PdfContainer createTableHeaderRow(XSSFSheet sheet, Range verticalRange);
 
-    public PdfContainer createVerticalRowWrapper(XSSFSheet sheet, Range verticalRange);
+    PdfContainer createVerticalRowWrapper(XSSFSheet sheet, Range verticalRange);
 
-    public PdfContainer createEmptyRow(XSSFSheet sheet, Range oneRowRange);
+    PdfContainer createEmptyRow(XSSFSheet sheet, Range oneRowRange);
 
-    public PdfPictureNode createPictureNode(XSSFSheet sheet, Picture picture);
+    PdfPictureNode createPictureNode(XSSFSheet sheet, Picture picture);
 
-	public PdfCellNode createWrappedCell(XSSFSheet sheet, XSSFCell cell, XLSXExpression expr);
+	PdfCellNode createWrappedCell(XSSFSheet sheet, XSSFCell cell, XLSXExpression expr);
 
-	public void makeCellWrappable(PdfCellNode cell);
+	void makeCellWrappable(PdfCellNode cell);
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/DrawablePdfElement.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/DrawablePdfElement.java
@@ -10,17 +10,17 @@ package com.exigeninsurance.x4j.analytic.xlsx.transform.pdf;
 
 public interface DrawablePdfElement {
 	
-	public void draw(RenderingContext renderingContext) throws Exception;
+	void draw(RenderingContext renderingContext) throws Exception;
 		
-	public float estimateWidth(RenderingContext context);
+	float estimateWidth(RenderingContext context);
 	
-	public float estimateHeight(RenderingContext context);
+	float estimateHeight(RenderingContext context);
 	
-	public void notify(PdfContext context);
+	void notify(PdfContext context);
 	
-	public void setParent(PdfContainer element);
+	void setParent(PdfContainer element);
 	
-	public PdfContainer getParent();
+	PdfContainer getParent();
 	
-	public float getHeigth();
+	float getHeigth();
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/PdfGridElement.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/PdfGridElement.java
@@ -11,5 +11,5 @@ import com.exigeninsurance.x4j.analytic.xlsx.transform.pdf.geometry.Range;
 
 public interface PdfGridElement {
 
-	public Range getVerticalRange();
+	Range getVerticalRange();
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Alignment.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Alignment.java
@@ -16,7 +16,7 @@ public enum Alignment {
 
 	private final short excel;
 
-	private Alignment(short excel) {
+	Alignment(short excel) {
 		this.excel = excel;
 	}
 

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Estimator.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Estimator.java
@@ -11,6 +11,6 @@ import com.exigeninsurance.x4j.analytic.xlsx.transform.pdf.RenderingContext;
 
 public interface Estimator {
 	
-	public float estimate(RenderingContext context);
+	float estimate(RenderingContext context);
 
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Notifier.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Notifier.java
@@ -11,5 +11,5 @@ import com.exigeninsurance.x4j.analytic.xlsx.transform.pdf.PdfContext;
 
 public interface Notifier {
 	
-	public void notify(PdfContext context);
+	void notify(PdfContext context);
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Processor.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Processor.java
@@ -11,6 +11,6 @@ import com.exigeninsurance.x4j.analytic.xlsx.transform.xlsx.XLXContext;
 
 public interface Processor {
 	
-	public void process(XLXContext context) throws Exception;
+	void process(XLXContext context) throws Exception;
 
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Renderer.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Renderer.java
@@ -13,5 +13,5 @@ import com.exigeninsurance.x4j.analytic.xlsx.transform.pdf.RenderingContext;
 
 public interface Renderer {
 
-	public void render(RenderingContext context) throws IOException;
+	void render(RenderingContext context) throws IOException;
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Style.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/components/Style.java
@@ -11,5 +11,5 @@ import com.exigeninsurance.x4j.analytic.xlsx.transform.PdfStyle;
 
 public interface Style {
 
-	public PdfStyle getStyle(com.exigeninsurance.x4j.analytic.xlsx.transform.TableStyle tableStyle);
+	PdfStyle getStyle(com.exigeninsurance.x4j.analytic.xlsx.transform.TableStyle tableStyle);
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/geometry/Range.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/geometry/Range.java
@@ -9,20 +9,20 @@ package com.exigeninsurance.x4j.analytic.xlsx.transform.pdf.geometry;
 
 public interface Range {
 	
-	public boolean inside(int number);
+	boolean inside(int number);
 	
-	public int getFirst();
+	int getFirst();
 	
-	public int getLast();
+	int getLast();
 	
-	public void setFirst(int number);
+	void setFirst(int number);
 	
-	public void setLast(int number);
+	void setLast(int number);
 	
-	public Range copy();
+	Range copy();
 
-	public boolean contains(Range range);
+	boolean contains(Range range);
 
-	public int length();
+	int length();
 
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/StyleCache.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/StyleCache.java
@@ -80,13 +80,10 @@ public class StyleCache {
 				if (currencyCd != null ? !currencyCd.equals(styleKey.currencyCd) : styleKey.currencyCd != null){
 					return false;
 				}
-					
-				if (!node.equals(styleKey.node)){
-					return false;
-				}
 
-				return true;
-			}
+                return node.equals(styleKey.node);
+
+            }
 
 			@Override
 			public int hashCode() {

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXCellNode.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXCellNode.java
@@ -8,6 +8,7 @@ package com.exigeninsurance.x4j.analytic.xlsx.transform.xlsx;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.Date;
 
@@ -32,14 +33,14 @@ import com.exigeninsurance.x4j.analytic.xlsx.utils.WrappingUtil;
 
 public final class XLSXCellNode extends CellNode {
 
-	private static final byte[] F_END = "</f>".getBytes();
-	private static final byte[] F = "<f>".getBytes();
-	private static final byte[] C_R = "<c r=\"".getBytes();
-	private static final byte[] C_TAIL = "</c>".getBytes();
-	private static final byte[] S = " s=\"".getBytes();
-	private static final byte[] T = " t=\"".getBytes();
-	private static final byte[] V = "<v>".getBytes();
-	private static final byte[] V_TAIL = "</v>".getBytes();	
+	private static final byte[] F_END = "</f>".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] F = "<f>".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] C_R = "<c r=\"".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] C_TAIL = "</c>".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] S = " s=\"".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] T = " t=\"".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] V = "<v>".getBytes(StandardCharsets.UTF_8);
+	private static final byte[] V_TAIL = "</v>".getBytes(StandardCharsets.UTF_8);
 	private static final byte QT = '\"';
 	private static final byte GT = '>';
 	private String formulaStringValue;

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXProcessor.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXProcessor.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -256,9 +257,9 @@ final class XLSXProcessor extends WorkbookProcessor {
 		String str = toString(sheet);
 		int index = str.indexOf("<cols/>");
 		if(index > 0){
-			out.write((str.substring(0, index) + "<sheetData>").getBytes());
+			out.write((str.substring(0, index) + "<sheetData>").getBytes(StandardCharsets.UTF_8));
 		}else {
-			out.write(str.substring(0, str.indexOf("<row")).getBytes());
+			out.write(str.substring(0, str.indexOf("<row")).getBytes(StandardCharsets.UTF_8));
 		}
 	}
 
@@ -275,7 +276,7 @@ final class XLSXProcessor extends WorkbookProcessor {
 		} catch (IOException e) {
 			throw new ReportException(e);
 		}
-		return new String(bout.toByteArray());
+		return new String(bout.toByteArray(), StandardCharsets.UTF_8);
 	}
 
 	private void setColWidths(XSSFSheet sheet, XLXContext context) {

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXRowNode.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXRowNode.java
@@ -11,6 +11,8 @@ import org.apache.poi.xssf.usermodel.XSSFSheet;
 
 import com.exigeninsurance.x4j.analytic.xlsx.core.node.Node;
 
+import java.nio.charset.StandardCharsets;
+
 
 public final class XLSXRowNode extends Node {
 
@@ -18,11 +20,11 @@ public final class XLSXRowNode extends Node {
 
 	private static final byte GT = '>';
 
-	private static final byte[] ROW_HEAD = "<row r=\"".getBytes();
+	private static final byte[] ROW_HEAD = "<row r=\"".getBytes(StandardCharsets.UTF_8);
 
-	private static final byte[] ROW_TAIL = "</row>".getBytes();
+	private static final byte[] ROW_TAIL = "</row>".getBytes(StandardCharsets.UTF_8);
 
-	private static final byte[] SPANS = " spans=\"".getBytes();
+	private static final byte[] SPANS = " spans=\"".getBytes(StandardCharsets.UTF_8);
 
 	private byte[] spans;
 
@@ -42,7 +44,7 @@ public final class XLSXRowNode extends Node {
 				}
 
 			}
-			spans = buffer.toString().getBytes();
+			spans = buffer.toString().getBytes(StandardCharsets.UTF_8);
 		}
 	}
 

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXStyleUtil.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXStyleUtil.java
@@ -90,7 +90,7 @@ public class XLSXStyleUtil {
 	}
 
 	private interface StyleTransformation {
-		public void transform(XSSFCellStyle cellStyle);
+		void transform(XSSFCellStyle cellStyle);
 	}
 
 	private class MoneyTransform implements StyleTransformation {

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXWorkbookTransaform.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/xlsx/XLSXWorkbookTransaform.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.Deflater;
@@ -154,7 +155,7 @@ final public class XLSXWorkbookTransaform extends BaseTransform {
 			head = head.replaceFirst("@uniqueCount@",
 					Long.toString(sst.getUnique()));
 
-			raf.write(head.getBytes());
+			raf.write(head.getBytes(StandardCharsets.UTF_8));
 		}finally{
 			raf.close();
 		}

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/utils/MacroNodeFactory.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/utils/MacroNodeFactory.java
@@ -13,11 +13,11 @@ import com.exigeninsurance.x4j.analytic.xlsx.core.node.Node;
 @Internal
 public interface MacroNodeFactory {
 
-    public Node parseSetMacro(String macro);
+    Node parseSetMacro(String macro);
 
-    public Node parseForMacro(String macro);
+    Node parseForMacro(String macro);
 
-    public Node parseEvalMacro(String macro);
+    Node parseEvalMacro(String macro);
 
-    public Node parseIfMacro(String macro);
+    Node parseIfMacro(String macro);
 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/utils/SectionParser.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/utils/SectionParser.java
@@ -55,11 +55,11 @@ public class SectionParser {
     }
 
     private interface ParseState {
-        public void processCharacter(SectionParser context, char token);
+        void processCharacter(SectionParser context, char token);
 
-        public void processAmpersand(SectionParser context, char token);
+        void processAmpersand(SectionParser context, char token);
 
-        public void processEnd(SectionParser context);
+        void processEnd(SectionParser context);
     }
 
     private void addSection(String contents, char sectionExpression) {

--- a/src/test/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/PdfSheetParserTest.java
+++ b/src/test/java/com/exigeninsurance/x4j/analytic/xlsx/transform/pdf/PdfSheetParserTest.java
@@ -260,7 +260,7 @@ public class PdfSheetParserTest {
 	}
 
 	private interface WithSheet {
-		public void execute(XSSFSheet sheet) throws Exception;
+		void execute(XSSFSheet sheet) throws Exception;
 	}
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1943 - "Classes and methods that rely on the default system encoding should not be used".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S1943
Please let me know if you have any questions.
Artyom Melnikov
