### PR TITLE
Fixing squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/core/node/GroupAdapter.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/core/node/GroupAdapter.java
@@ -7,10 +7,7 @@
 package com.exigeninsurance.x4j.analytic.xlsx.core.node;
 
 import java.sql.ResultSet;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Stack;
+import java.util.*;
 
 import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.commons.lang.ObjectUtils;
@@ -34,7 +31,7 @@ public class GroupAdapter implements ResultSetAdapter {
 	@SuppressWarnings("unchecked")
 	private Map<String, Object> nextRow = new CaseInsensitiveMap();
  	private final LinkedHashMap<String, Group> groups = new LinkedHashMap<String, Group>();
- 	private final Stack<String> stack = new Stack<String>();
+ 	private final Deque<String> stack = new ArrayDeque<String>();
 
 	public GroupAdapter(ResultSet rs) {
         this(ResultSetWrapper.wrap(rs));

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/SheetParser.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/SheetParser.java
@@ -7,13 +7,7 @@
 package com.exigeninsurance.x4j.analytic.xlsx.transform;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
+import java.util.*;
 
 import org.apache.poi.POIXMLDocumentPart;
 import org.apache.poi.POIXMLRelation;
@@ -59,7 +53,7 @@ public abstract class SheetParser {
 			) {
 	};
 
-	private final Stack<Node> stack = new Stack<Node>();
+	private final Deque<Node> stack = new ArrayDeque<Node>();
 	private int lastRowNum;
 
 	private XSSFSheet sheet;
@@ -77,8 +71,8 @@ public abstract class SheetParser {
 	private final boolean showRowColHeaders = true;
 
 	private ReportContext reportContext;
-	private final Stack<SimpleRange> tableRanges = new Stack<SimpleRange>();
-	private final Stack<SimpleRange> openLoops = new Stack<SimpleRange>();
+	private final Deque<SimpleRange> tableRanges = new ArrayDeque<SimpleRange>();
+	private final Deque<SimpleRange> openLoops = new ArrayDeque<SimpleRange>();
 	private Map<String, MergedRegion> mergedCellMap;
 	private Collection<MergedRegion> mergedRegions = new ArrayList<MergedRegion>();
 
@@ -415,10 +409,10 @@ public abstract class SheetParser {
 	}
 
 	private boolean forEachLoops(int row) {
-		if (!openLoops.empty()) {
+		if (!openLoops.isEmpty()) {
 			return true;
 		}
-		if (tableRanges.empty()) {
+		if (tableRanges.isEmpty()) {
 			return false;
 		}
 		for (SimpleRange range : tableRanges) {

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/html/HTMLProcessor.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/html/HTMLProcessor.java
@@ -50,7 +50,7 @@ public class HTMLProcessor extends WorkbookProcessor {
 
 	public void processSheets(	ReportContext reportContext, List<String> savedParts	)
 	throws  Exception {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("<style>");
 
 		int len =  styles._getXfsSize();
@@ -94,7 +94,7 @@ public class HTMLProcessor extends WorkbookProcessor {
 		context.flush();
 	}
 
-	private void appendStyle(StringBuffer buffer, int i) {
+	private void appendStyle(StringBuilder buffer, int i) {
 		buffer.append(".c").append(i).append("{");
 		XSSFCellStyle style  = styles.getStyleAt(i);
 		appendFontStyle(buffer, style);
@@ -102,7 +102,7 @@ public class HTMLProcessor extends WorkbookProcessor {
 		buffer.append("}\n");
 	}
 
-	private void appendAlign(StringBuffer buffer, XSSFCellStyle style) {
+	private void appendAlign(StringBuilder buffer, XSSFCellStyle style) {
 		switch(style.getAlignment()){
 		case CellStyle.ALIGN_GENERAL:
 			break;
@@ -118,7 +118,7 @@ public class HTMLProcessor extends WorkbookProcessor {
 		}
 	}
 
-	private void appendFontStyle(StringBuffer buffer, XSSFCellStyle style) {
+	private void appendFontStyle(StringBuilder buffer, XSSFCellStyle style) {
 		XSSFFont font = style.getFont();
 		buffer.append("font-size:").append(font.getFontHeightInPoints()).append("pt;");
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1149 - "Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S1149
Please let me know if you have any questions.
Artyom Melnikov