### PR TITLE
Fixing squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing

### DIFF
--- a/src/main/java/com/exigeninsurance/x4j/analytic/model/ReportMetadata.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/model/ReportMetadata.java
@@ -255,7 +255,7 @@ public class ReportMetadata implements Serializable{
 		if (templates != null) {
 			List <Format> formats = templates.getFormat();
 			for (Format format : formats) {
-				if (format.getName().trim().toLowerCase().equals(cleanedUpFormat)) {
+				if (format.getName().trim().equalsIgnoreCase(cleanedUpFormat)) {
 					return true;
 				}
 			}
@@ -271,7 +271,7 @@ public class ReportMetadata implements Serializable{
 		if (templates != null) {
 			List <Format> formats = templates.getFormat();
 			for (Format format : formats) {
-				if (format.getName().trim().toLowerCase().equals(cleanedUpFormat)) {
+				if (format.getName().trim().equalsIgnoreCase(cleanedUpFormat)) {
 					return format.getTemplate();
 				}
 			}

--- a/src/main/java/com/exigeninsurance/x4j/analytic/util/MockResultSet.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/util/MockResultSet.java
@@ -62,7 +62,7 @@ abstract public class MockResultSet implements ResultSet {
                     }else {
                         int index = 0;
                         for (String colName : columns){
-                            if(colName.toUpperCase().equals(args[0].toString().toUpperCase())){
+                            if(colName.equalsIgnoreCase(args[0].toString())){
                                 if(generate > 0 && rows[currentRow][ index ] instanceof String){
                                     rows[currentRow][ index ] = System.currentTimeMillis() + "0";
                                 }

--- a/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/AlignmentFinder.java
+++ b/src/main/java/com/exigeninsurance/x4j/analytic/xlsx/transform/AlignmentFinder.java
@@ -53,6 +53,6 @@ public class AlignmentFinder {
 	}
 
 	private boolean isEnabled(Attribute a) {
-		return a == null || a.getValue().toLowerCase().equals("enabled");
+		return a == null || a.getValue().equalsIgnoreCase("enabled");
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1157 - "Case insensitive string comparisons should be made without intermediate upper or lower casing".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S1157
Please let me know if you have any questions.
Artyom Melnikov